### PR TITLE
Adding the event for the RobotEndMovingBackward (of Pinky) at the end…

### DIFF
--- a/code/PinkyAndBrain/PinkyAndBrain/ControlLoop.cs
+++ b/code/PinkyAndBrain/PinkyAndBrain/ControlLoop.cs
@@ -1698,12 +1698,12 @@ namespace PinkyAndBrain
                 });
             }
 
-            Thread.Sleep((int)(_currentTrialTimings.wPostTrialTime * 1000));
-
             //wait the maximum time of the postTrialTime and the going home position time.
             moveRobotHomePositionTask.Wait();
             //also send the AlphaOmega that motion backwards ends.
             _alphaOmegaEventsWriter.WriteEvent(true, AlphaOmegaEvent.RobotEndMovingBackward);
+
+            Thread.Sleep((int)(_currentTrialTimings.wPostTrialTime * 1000));
 
             _logger.Info("PostTrialStage ended. TrialSucceed = " + trialSucceed + ".");
             return trialSucceed;


### PR DESCRIPTION
… of the waits for the movement and not at the end of the waits for the PostTrialTime.